### PR TITLE
Fixes

### DIFF
--- a/src/main/kotlin/versioning/VersioningPlugin.kt
+++ b/src/main/kotlin/versioning/VersioningPlugin.kt
@@ -10,13 +10,17 @@ import versioning.git.Repository
 
 class VersioningPlugin : Plugin<Project> {
 
+    companion object {
+        const val INCREASE_VERSION_TASK_NAME = "increaseVersion"
+    }
+
     // Visible for testing
     var repository: Repository? = null
 
     override fun apply(project: Project): Unit {
 
         repository = repository ?: if (isVersioned(project)) {
-            GitRepository()
+            GitRepository(project.logger)
         } else {
             NoOpRepository()
         }
@@ -30,12 +34,15 @@ class VersioningPlugin : Plugin<Project> {
         project.extensions.create("versioning",
                 VersioningExtension::class.java, versionNamingStrategy.versionCode, versionNamingStrategy.versionName)
 
-        project.tasks.create("increaseVersion", IncreaseVersionTask::class.java) {
+        project.tasks.create(INCREASE_VERSION_TASK_NAME, IncreaseVersionTask::class.java) {
             it.group = "Versioning"
             it.description = "Increase version in given _scope_ and tag current commit with new version."
-            it.repository = if (isVersioned(project)) repository!! else GitRepository()
+            it.repository = repository!!
         }
     }
 
-    fun isVersioned(project: Project): Boolean = project.findProperty("versioned")?.toString().equals("true", ignoreCase = true)
+    fun isVersioned(project: Project): Boolean =
+            project.hasProperty("versioned")
+                    || project.hasProperty("scope")
+                    || project.gradle.startParameter.taskNames.contains(INCREASE_VERSION_TASK_NAME)
 }

--- a/src/test/kotlin/versioning/VersioningPluginTest.kt
+++ b/src/test/kotlin/versioning/VersioningPluginTest.kt
@@ -54,18 +54,6 @@ class VersioningPluginTest {
     }
 
     @Test
-    fun versionIsStubbedWhenExplicitlyNotVersioned() {
-        project.addVersionedProperty(false)
-
-        plugin.apply(project)
-
-        assertThat(project.versioningExtension.currentVersionCode).isEqualTo(1)
-        assertThat(project.versioningExtension.currentVersionName).isEqualTo("non-versioned")
-
-        verifyZeroInteractions(repository)
-    }
-
-    @Test
     fun versionIsInferredProperlyWhenOnTag() {
         project.addVersionedProperty(true)
 

--- a/src/test/kotlin/versioning/git/GitRepositoryTest.kt
+++ b/src/test/kotlin/versioning/git/GitRepositoryTest.kt
@@ -1,5 +1,6 @@
 package versioning.git
 
+import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.internal.storage.file.FileRepository
@@ -21,7 +22,7 @@ class GitRepositoryTest : LocalDiskRepositoryTestCase() {
         super.setUp()
 
         repositoryFolder = createWorkRepository()
-        repository = GitRepository(repositoryFolder)
+        repository = GitRepository(mock(), repositoryFolder)
         actualRepo = Git.wrap(repositoryFolder)
 
         JGitTestUtil.writeTrashFile(repositoryFolder, "readme", "[empty]")


### PR DESCRIPTION
Allow only -Pversioned property to exist, without being explicitly set to 'true'

Version the project also when scope is provided only, or when increase task is called

Add a message if pushing tag has failed